### PR TITLE
Bruk custom lenkepanel med Link fra react-router-dom

### DIFF
--- a/src/component/GjennomforingPanel.tsx
+++ b/src/component/GjennomforingPanel.tsx
@@ -1,9 +1,10 @@
-import { Heading, LinkPanel } from '@navikt/ds-react'
+import { Heading } from '@navikt/ds-react'
 import React from 'react'
 
 import styles from './GjennomforingPanel.module.scss'
 import { Gjennomforing } from '../api/api'
 import { appUrl } from '../utils/url-utils'
+import { SpaLenkepanel } from './spa-lenkepanel/SpaLenkepanel'
 
 interface GjennomforingPanelProps {
 	gjennomforing : Gjennomforing
@@ -11,10 +12,10 @@ interface GjennomforingPanelProps {
 
 export const GjennomforingPanel = ({ gjennomforing }: GjennomforingPanelProps) : React.ReactElement => {
 	return (
-		<LinkPanel href={appUrl(`/gjennomforing/${gjennomforing.id}`)} className={styles.panel}>
+		<SpaLenkepanel to={appUrl(`/gjennomforing/${gjennomforing.id}`)} className={styles.panel}>
 			<Heading size="xsmall">
 				{gjennomforing.navn}
 			</Heading>
-		</LinkPanel>
+		</SpaLenkepanel>
 	)
 }

--- a/src/component/spa-lenkepanel/SpaLenkepanel.module.scss
+++ b/src/component/spa-lenkepanel/SpaLenkepanel.module.scss
@@ -1,0 +1,8 @@
+@import '/src/colors.scss';
+
+.spaLenkepanel {
+  background-color: white;
+  padding: 1rem;
+  border: 1px solid $navGra60;
+  border-radius: 4px;
+}

--- a/src/component/spa-lenkepanel/SpaLenkepanel.tsx
+++ b/src/component/spa-lenkepanel/SpaLenkepanel.tsx
@@ -1,0 +1,28 @@
+import { Next } from '@navikt/ds-icons'
+import cls from 'classnames'
+import React from 'react'
+import { Link } from 'react-router-dom'
+
+import styles from './SpaLenkepanel.module.scss'
+
+interface SpaLenkepanelProps {
+	to: string;
+	children?: React.ReactNode;
+	className?: string;
+}
+
+export const SpaLenkepanel = (props: SpaLenkepanelProps): React.ReactElement<SpaLenkepanelProps> => {
+	const { to, children, className } = props
+
+	return (
+		<Link to={to} className={cls('navds-link-panel', styles.spaLenkepanel, className)}>
+			<div className="navds-link-panel__content">
+				{children}
+			</div>
+			<Next
+				className="navds-link-panel__chevron"
+				aria-label="arrow-icon pointing right"
+			/>
+		</Link>
+	)
+}


### PR DESCRIPTION
Siden vi har en SPA-app så burde alle interne lenker bruke react-router-dom så vi slipper å laste inn hele siden på nytt