### PR TITLE
Fjern tilganger fra InnloggetAnsatt

### DIFF
--- a/src/api/schema/schema.ts
+++ b/src/api/schema/schema.ts
@@ -10,7 +10,6 @@ export const TiltakSchema = z.object({
 export const InnloggetNavAnsattSchema = z.object({
 	navIdent: z.string(),
 	navn: z.string(),
-	tilganger: z.array(z.string())
 })
 
 export const ArrangorAnsattSchema = z.object({

--- a/src/mock/data.ts
+++ b/src/mock/data.ts
@@ -3,29 +3,28 @@ import faker from 'faker'
 import { InnloggetNavAnsatt } from '../api/api'
 
 interface Gjennomforing {
-    navn: string,
-    id: string,
-    arrangor: {
-        organisasjonNavn: string | null,
-        organisasjonOrgnr: string | null,
-        virksomhetNavn: string,
-        virksomhetOrgnr: string,
-    },
-    lopenr: number,
-    opprettetAr: number,
-    startDato: Date,
-    sluttDato: Date,
-    antallAktiveEndringsmeldinger: number,
-    tiltak: {
-        kode: string,
-        navn: string,
-    },
+	navn: string,
+	id: string,
+	arrangor: {
+		organisasjonNavn: string | null,
+		organisasjonOrgnr: string | null,
+		virksomhetNavn: string,
+		virksomhetOrgnr: string,
+	},
+	lopenr: number,
+	opprettetAr: number,
+	startDato: Date,
+	sluttDato: Date,
+	antallAktiveEndringsmeldinger: number,
+	tiltak: {
+		kode: string,
+		navn: string,
+	},
 }
 
 export const innloggetAnsatt: InnloggetNavAnsatt = {
 	navIdent: 'Z1234',
 	navn: faker.name.firstName() + ' ' + faker.name.lastName(),
-	tilganger: [ 'FLATE', 'ENDRINGSMELDING' ]
 }
 
 export const gjennomforinger: Gjennomforing[] = [

--- a/src/utils/error-utils.ts
+++ b/src/utils/error-utils.ts
@@ -1,0 +1,7 @@
+import { AxiosError } from 'axios'
+
+export const getStatusCode = (error: Error): number | undefined => {
+	const err: AxiosError = error as AxiosError
+	return err.response?.status
+
+}

--- a/src/utils/tilgang-utils.ts
+++ b/src/utils/tilgang-utils.ts
@@ -1,6 +1,0 @@
-
-export const TILGANG_ENDRINGSMELDING = 'ENDRINGSMELDING'
-
-export const harTilgangTilEndringsmelding = (tilganger: string[]) => {
-	return tilganger.includes(TILGANG_ENDRINGSMELDING)
-}


### PR DESCRIPTION
Rydder opp i tilgangsstyring, hvor vi nå autoriserer tilganger via azureAd-tokenet i stedet.