### PR TITLE
Legg til gruppering av dependabot PRer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,13 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
+    groups:
+      minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Dette skal, forhåpentligvis, gjøre at dependabot grupperer alle mindre oppdateringer i en enkelt PR. Man kan jo også gruppere annerledes, jeg tror man kan matche på pakker som kommer fra designsystemet f.eks hvis man bare vil gruppere de.

Kanskje dere fant ut at dette er en dårlig ide, men hvis ikke kan vi teste det.