### PR TITLE
Oppdater infotekst etter lansering

### DIFF
--- a/src/page/forside/Forside.module.scss
+++ b/src/page/forside/Forside.module.scss
@@ -20,16 +20,15 @@
   margin-bottom: 0.5rem;
 }
 .linke_navet {
-  margin-bottom: 1rem;
-  font-size: 1.125rem;
-}
-.linke_nav {
   font-size: 1.125rem;
 }
 
 .list_title {
-  h3 {
-    font-size: var(--a-font-size-large);
-    font-weight: normal
+  margin-top: 1rem;
+  }
+  
+  .list {
+    ul {
+      margin-top: 0.5rem;
   }
 }

--- a/src/page/forside/Forside.tsx
+++ b/src/page/forside/Forside.tsx
@@ -4,7 +4,8 @@ import {
 	BodyLong,
 	Heading,
 	Link as SimpleLink,
-	Loader
+	Loader,
+	List
 } from '@navikt/ds-react'
 import cls from 'classnames'
 import React from 'react'
@@ -49,31 +50,30 @@ export const Forside = (): React.ReactElement => {
 					className={styles.alert_heading}
 				>
 					Fra 10. desember kan du ikke endre deltakelser i Arena for
-					tiltakene digitalt oppfølgingstiltak og VTA
+					tiltakene digitalt jobbsøkerkurs og VTA
 				</Heading>
 				<BodyLong>
-					Den nye løsningen for påmelding og endring av deltakelse for Nav-veileder blir snart tilgjengelig
-					for disse tiltakene. Tiltaksarrangør kan sende forslag om endringer direkte til Nav-veileder.
+					Nav-veileder har fått ny løsning i Modia for påmelding og
+					endring av deltakelse. Tiltaksarrangør kan sende forslag om
+					endringer direkte til Nav-veileder.
 				</BodyLong>
+				<BodyLong className={styles.list_title}>
+					Så langt er følgende tiltak over på ny påmeldingsløsning:
+				</BodyLong>
+				<List className={styles.list}>
+					<List.Item>15. oktober: AFT</List.Item>
+					<List.Item>
+						19. november: oppfølging, avklaring og ARR
+					</List.Item>
+					<List.Item>
+						10. desember: digitalt jobbsøkerkurs og VTA
+					</List.Item>
+				</List>
 				<SimpleLink
 					className={styles.linke_navet}
 					href="https://navno.sharepoint.com/sites/intranett-produktomrader-og-prosjekter/SitePages/Ny-l%C3%B8sning-for-p%C3%A5melding-til-arbeidsforberedende-trening.aspx"
 				>
 					Les mer om ny løsning på Navet.
-				</SimpleLink>
-
-				<BodyLong weight="semibold">
-					FRIST: Alle endringsmeldinger for digitalt oppfølgingstiltak og
-					VTA må legges inn i Arena innen 9. des. kl. 15
-				</BodyLong>
-				<BodyLong>
-					Fra 5. des. kl. 15 kan ikke tiltaksarrangør sende inn nye endringsmeldinger.
-				</BodyLong>
-				<SimpleLink
-					className={styles.linke_nav}
-					href="https://www.nav.no/nytt-i-deltakeroversikten"
-				>
-					Tiltaksarrangør er informert her på nav.no.
 				</SimpleLink>
 			</Alert>
 			<GjennomforingListe gjennomforinger={gjennomforinger} />

--- a/src/page/forside/Forside.tsx
+++ b/src/page/forside/Forside.tsx
@@ -4,8 +4,8 @@ import {
 	BodyLong,
 	Heading,
 	Link as SimpleLink,
-	Loader,
-	List
+	List,
+	Loader
 } from '@navikt/ds-react'
 import cls from 'classnames'
 import React from 'react'


### PR DESCRIPTION
https://trello.com/c/o246PosR/2024-oppdater-infotekster-om-lansering-av-vta-og-digital-jobbs%C3%B8kerkurs